### PR TITLE
Add progress spinner for parallel scanning

### DIFF
--- a/src/ai_bom/cli.py
+++ b/src/ai_bom/cli.py
@@ -462,8 +462,17 @@ def scan(
 
                 if format == "table" and not quiet:
                     console.print(f"[dim]Parallel scanning with {workers} workers[/dim]")
-
-                components = run_scanners_parallel(scanners, scan_path, workers=workers)
+                    with Progress(
+                        SpinnerColumn(),
+                        TextColumn("[progress.description]{task.description}"),
+                        console=console,
+                        transient=True,
+                    ) as progress:
+                        task = progress.add_task("Scanning...", total=None)
+                        components = run_scanners_parallel(scanners, scan_path, workers=workers)
+                        progress.update(task, completed=True)
+                else:
+                    components = run_scanners_parallel(scanners, scan_path, workers=workers)
                 for comp in components:
                     comp.risk = score_component(comp)
                 result.components.extend(components)


### PR DESCRIPTION
## Summary

When using the `--workers` flag for parallel scanning, adds a spinner progress indicator so users get visual feedback during longer scans.

## Changes

- Modified `src/ai_bom/cli.py` to wrap parallel scanning with Rich `Progress` component
- Shows spinner with "Scanning..." message during parallel scans
- Only displays when using table format and not in quiet mode

This addresses issue #27 by providing visual feedback during long-running parallel scans.

If this PR is helpful, tips appreciated via Lightning: max@klabo.world
