### PR TITLE
Add JSON Schema validation for output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ That's it. Scans your project and prints a risk-scored inventory of every AI com
 # CycloneDX SBOM for compliance
 ai-bom scan . -f cyclonedx -o ai-bom.cdx.json
 
+# Validate JSON output against schema
+ai-bom scan . -f cyclonedx --validate
+
 # SARIF for GitHub Code Scanning
 ai-bom scan . -f sarif -o results.sarif
 
@@ -327,6 +330,15 @@ graph LR
 | SPDX 3.0 | `-f spdx3` | SPDX-compatible with AI extensions |
 | CSV | `-f csv` | Spreadsheet analysis |
 | JUnit | `-f junit` | CI/CD test reporting |
+
+## JSON Schema Validation
+
+AI-BOM provides a built-in JSON Schema for validating scan results, ensuring they conform to the expected structure (CycloneDX 1.6 + Trusera extensions).
+
+- **Schema file:** `src/ai_bom/schema/bom-schema.json`
+- **Validation command:** `ai-bom scan . --format cyclonedx --validate`
+
+This is particularly useful in CI/CD pipelines to ensure generated SBOMs are valid before ingestion into tools like Dependency-Track.
 
 <details>
 <summary>CycloneDX output example</summary>

--- a/src/ai_bom/schema/bom-schema.json
+++ b/src/ai_bom/schema/bom-schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AI-BOM CycloneDX Export",
+  "description": "JSON Schema for AI-BOM's CycloneDX 1.6 output format with Trusera extensions.",
+  "type": "object",
+  "required": ["bomFormat", "specVersion", "version", "serialNumber", "metadata", "components"],
+  "properties": {
+    "bomFormat": {
+      "type": "string",
+      "const": "CycloneDX"
+    },
+    "specVersion": {
+      "type": "string",
+      "const": "1.6"
+    },
+    "version": {
+      "type": "integer"
+    },
+    "serialNumber": {
+      "type": "string",
+      "pattern": "^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["timestamp", "tools", "properties"],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tools": {
+          "type": "object"
+        },
+        "properties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["bom-ref", "type", "name", "description", "properties", "purl"],
+        "properties": {
+          "bom-ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "application",
+              "framework",
+              "library",
+              "container",
+              "machine-learning-model",
+              "service",
+              "file"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "purl": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/property"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "property": {
+      "type": "object",
+      "required": ["name", "value"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/ai_bom/utils/validator.py
+++ b/src/ai_bom/utils/validator.py
@@ -1,0 +1,30 @@
+"""JSON Schema validation for AI-BOM output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from jsonschema import validate
+
+
+def get_schema() -> dict[str, Any]:
+    """Load the AI-BOM JSON schema."""
+    schema_path = Path(__file__).parent.parent / "schema" / "bom-schema.json"
+    with open(schema_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_output(data: dict[str, Any]) -> None:
+    """Validate scan output against the JSON schema.
+
+    Args:
+        data: The JSON-compatible dict to validate.
+
+    Raises:
+        jsonschema.ValidationError: If validation fails.
+    """
+    schema = get_schema()
+    validate(instance=data, schema=schema)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,3 +248,13 @@ def test_scan_no_star_message_in_json_format():
     # JSON format should only contain JSON output, not the star message
     data = json.loads(result.output)
     assert "bomFormat" in data  # Valid CycloneDX JSON
+
+
+def test_scan_validate_schema():
+    """Test that --validate flag works for JSON output."""
+    demo_file = Path(__file__).parent.parent / "examples" / "demo-project" / "app.py"
+    result = runner.invoke(app, ["scan", str(demo_file), "--format", "json", "--validate"])
+    assert result.exit_code == 0
+    # Output should still be valid JSON
+    data = json.loads(result.output)
+    assert "bomFormat" in data

--- a/tests/test_output_schemas.py
+++ b/tests/test_output_schemas.py
@@ -236,15 +236,16 @@ class TestCycloneDXSchemaValidation:
                     assert isinstance(prop["name"], str)
                     assert isinstance(prop["value"], str)
 
-    @pytest.mark.skipif(not JSONSCHEMA_AVAILABLE, reason="jsonschema not installed")
     def test_cyclonedx_schema_validation(self, multi_component_result):
         """Test that output validates against CycloneDX schema."""
+        from ai_bom.utils.validator import get_schema
         reporter = CycloneDXReporter()
         output = reporter.render(multi_component_result)
         parsed = json.loads(output)
 
         # Validate against schema
-        validator = Draft7Validator(CYCLONEDX_SCHEMA)
+        schema = get_schema()
+        validator = Draft7Validator(schema)
         errors = list(validator.iter_errors(parsed))
         assert len(errors) == 0, f"Schema validation errors: {errors}"
 


### PR DESCRIPTION
This PR adds built-in JSON Schema validation for scan outputs to ensure they conform to the CycloneDX 1.6 specification and custom extensions. Closes #26.